### PR TITLE
chore(renovate): Avoid explicitly enabling pre-commit

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,4 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["github>camunda/infra-renovate-config:default.json5"],
-  "pre-commit": {
-    enabled: true,
-  },
 }


### PR DESCRIPTION
Already enabled in the shared config: https://github.com/camunda/infra-renovate-config/blob/main/default.json5#L9