### PR TITLE
chore(renovate): Use own config as using private shared one is not possible

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,4 +1,33 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
-  extends: ["github>camunda/infra-renovate-config:default.json5"],
+  extends: [
+    "config:recommended",
+    ":automergeDisabled",
+    ":semanticCommits",
+    ":dependencyDashboard",
+    ":enablePreCommit",
+    // cannot use shared config, it's in a private repo (https://github.com/renovatebot/renovate/discussions/26300):
+    // "github>camunda/infra-renovate-config:default.json5"
+  ],
+  schedule: ["every weekend"],
+  platformAutomerge: false,
+  separateMajorMinor: false,
+  commitBodyTable: true,
+  major: {
+    enabled: true,
+  },
+  minor: {
+    enabled: true,
+  },
+  patch: {
+    enabled: true,
+  },
+  packageRules: [
+    {
+      matchUpdateTypes: ["minor", "patch"],
+      matchManagers: ["github-actions"],
+      addLabels: ["automerge"],
+      automerge: true,
+    },
+  ]
 }


### PR DESCRIPTION
Context: https://github.com/renovatebot/renovate/discussions/26300