### PR TITLE
ci: validate pr titles

### DIFF
--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -1,0 +1,10 @@
+---
+name: Validate PR Title
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+jobs:
+  validate-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: camunda/infra-global-github-actions/teams/infra/pull-request/validate-title@main


### PR DESCRIPTION
Added workflow to validate PR titles to comply with the conventional commits standard.

Related: https://github.com/camunda/team-infrastructure/issues/813